### PR TITLE
Improve docs and add basic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Orca Chat
+
+Personal playground for orchestrating chat models with LangChain and Ollama.
+The project requires Python 3.12 or newer and is not yet packaged for general use.
+
+## Quickstart
+
+```bash
+git clone <this repo>
+cd orca
+pip install -e .[dev]
+```
+
+Set environment variables to point at your models (or rely on the defaults):
+
+```
+CHAT_MODEL_NAME=<name>
+CHAT_MODEL_URL=<http://host:port>
+SUMMARIZER_MODEL_NAME=<name>
+SUMMARIZER_MODEL_URL=<http://host:port>
+```
+
+Run the built-in demo:
+
+```bash
+python -m orca_chat
+```
+
+It will stream a response for a sample prompt and log stage transitions and
+summaries to the console.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@ The project requires Python 3.12 or newer and is not yet packaged for general us
 
 ## Quickstart
 
-```bash
-git clone <this repo>
-cd orca
-pip install -e .[dev]
-```
-
 Set environment variables to point at your models (or rely on the defaults):
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "orca"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
     "langchain-chroma>=0.2.4",
     "langchain-community>=0.3.26",
@@ -28,7 +28,7 @@ dev = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py313"
+target-version = "py312"
 fix = true
 lint.select = [
     "E",  # pycodestyle errors

--- a/src/orca_chat/__main__.py
+++ b/src/orca_chat/__main__.py
@@ -16,7 +16,7 @@ PROMPT = "Explain why the sky is blue."
 
 
 def _build_registry() -> LLMRegistry:
-    """Populate an :class:`LLMRegistry` from environment variables."""
+    """Populate a :class:`LLMRegistry` from environment variables."""
     registry = LLMRegistry()
 
     chat_cfg = LLMConfig(

--- a/src/orca_chat/__main__.py
+++ b/src/orca_chat/__main__.py
@@ -1,8 +1,13 @@
+"""Simple command line demo for :mod:`orca_chat`."""
+
 import asyncio
+import logging
 import os
 
 from orca_chat.config import LLMConfig, LLMRegistry
 from orca_chat.controller import ChatController
+
+logging.basicConfig(level=logging.INFO)
 
 __all__ = ["demo"]
 
@@ -11,6 +16,7 @@ PROMPT = "Explain why the sky is blue."
 
 
 def _build_registry() -> LLMRegistry:
+    """Populate an :class:`LLMRegistry` from environment variables."""
     registry = LLMRegistry()
 
     chat_cfg = LLMConfig(
@@ -31,6 +37,7 @@ def _build_registry() -> LLMRegistry:
 
 
 async def demo() -> None:
+    """Stream a single reply for ``PROMPT`` using the configured models."""
     registry = _build_registry()
     controller = ChatController(registry, default_alias="chat", summarizer_alias="summarizer")
 

--- a/src/orca_chat/controller.py
+++ b/src/orca_chat/controller.py
@@ -1,3 +1,6 @@
+"""High-level orchestration of chat sessions."""
+
+import logging
 from collections.abc import AsyncIterator, Callable
 
 from langchain_core.retrievers import BaseRetriever
@@ -9,10 +12,13 @@ from orca_chat.config import LLMConfig, LLMRegistry
 from orca_chat.history import SessionState
 from orca_chat.stages import ChatStage, StageTracker
 
+logger = logging.getLogger(__name__)
+
 __all__ = ["ChatController"]
 
 
 class ChatController:
+    """Manage chat conversations and running summaries for multiple sessions."""
     def __init__(
         self,
         registry: LLMRegistry,
@@ -22,6 +28,21 @@ class ChatController:
         retrieval_factory: Callable[[str], BaseRetriever] | None = None,
         stage_tracker: StageTracker | None = None,
     ) -> None:
+        """Create a new controller.
+
+        Parameters
+        ----------
+        registry:
+            Mapping of model aliases to :class:`LLMConfig` objects.
+        default_alias:
+            Alias of the chat model to use for regular conversations.
+        summarizer_alias:
+            Alias of the model used for history summarization.
+        retrieval_factory:
+            Optional callback returning a :class:`BaseRetriever` for an alias.
+        stage_tracker:
+            Custom :class:`StageTracker` for monitoring stage transitions.
+        """
         self._registry = registry
         self._default_alias = default_alias or next(iter(registry))
         self._summarizer_alias = summarizer_alias or self._default_alias
@@ -38,6 +59,7 @@ class ChatController:
         session_id: str,
         message: str,
     ) -> str:
+        """Return the model's reply as a single string."""
         self._stage_tracker.set(session_id, ChatStage.SENDING_TO_MODEL)
         chain = self._get_chain(session_id, self._default_alias)
         cfg: RunnableConfig = {"configurable": {"session_id": session_id}}
@@ -56,6 +78,7 @@ class ChatController:
         session_id: str,
         message: str,
     ) -> AsyncIterator[str]:
+        """Yield the reply token by token as it is generated."""
         self._stage_tracker.set(session_id, ChatStage.SENDING_TO_MODEL)
         chain = self._get_chain(session_id, self._default_alias)
         cfg: RunnableConfig = {"configurable": {"session_id": session_id}}
@@ -71,17 +94,21 @@ class ChatController:
         return
 
     def stage(self, session_id: str) -> ChatStage:
+        """Return the current :class:`ChatStage` for ``session_id``."""
         return self._stage_tracker.get(session_id)
 
     def _state(self, session_id: str) -> SessionState:
+        """Lazy-initialize and return ``SessionState`` for ``session_id``."""
         return self._states.setdefault(session_id, SessionState())
 
     def _ensure_summarizer(self, alias: str) -> None:
+        """Instantiate the summarizer chain for ``alias`` if needed."""
         if alias not in self._summarizers:
             cfg: LLMConfig = self._registry[alias]
             self._summarizers[alias] = build_summarizer(cfg)
 
     def _get_chain(self, session_id: str, alias: str):
+        """Return the chat chain for ``session_id`` and ``alias``."""
         key = (session_id, alias)
         if key in self._chains:
             return self._chains[key]
@@ -101,6 +128,7 @@ class ChatController:
         return chain
 
     async def _refresh_summary(self, session_id: str, alias: str) -> None:
+        """Regenerate the running summary for ``session_id``."""
         self._ensure_summarizer(alias)
         summarizer = self._summarizers[alias]
 
@@ -108,4 +136,4 @@ class ChatController:
         new_summary = await summarizer.ainvoke({"history": state.history.messages})
         state.summary = str(new_summary).strip()
 
-        print(f"\n\n[{alias}] summary -> {session_id}]: {state.summary[:200]!r}", flush=True)
+        logger.info("[%s] summary -> %s: %s", alias, session_id, state.summary[:200])

--- a/src/orca_chat/stages.py
+++ b/src/orca_chat/stages.py
@@ -1,7 +1,14 @@
+"""Lightweight state tracking for chat sessions."""
+
+import logging
 from enum import Enum, auto
+
+logger = logging.getLogger(__name__)
 
 
 class ChatStage(Enum):
+    """Discrete states in the chat flow."""
+
     WAITING_FOR_USER = auto()
     SENDING_TO_MODEL = auto()
     STREAM_FROM_CHAT = auto()
@@ -9,12 +16,16 @@ class ChatStage(Enum):
 
 
 class StageTracker:
+    """Keep track of the current :class:`ChatStage` for each session."""
+
     def __init__(self) -> None:
         self._stages: dict[str, ChatStage] = {}
 
     def set(self, session_id: str, stage: ChatStage) -> None:
+        """Record ``stage`` for ``session_id`` and log the transition."""
         self._stages[session_id] = stage
-        print(f"[stage → {session_id}]: {stage.name}", flush=True)
+        logger.info("[stage → %s]: %s", session_id, stage.name)
 
     def get(self, session_id: str) -> ChatStage:
+        """Return the most recent stage for ``session_id``."""
         return self._stages.get(session_id, ChatStage.WAITING_FOR_USER)


### PR DESCRIPTION
## Summary
- explain how to use the project via a new README
- document controller and stage tracker classes
- log stage transitions and summarization
- add simple docstrings to the demo
- downgrade to Python 3.12

## Testing
- `ruff check --fix`
- `python -m compileall -q src/orca_chat`


------
https://chatgpt.com/codex/tasks/task_e_68644a93fc008327bfa820fba0662b79