### PR TITLE
Improve resilience for chat models

### DIFF
--- a/src/orca_chat/__main__.py
+++ b/src/orca_chat/__main__.py
@@ -56,5 +56,12 @@ async def demo() -> None:
     log.info("Done!")
 
 
+def _run() -> None:
+    try:
+        asyncio.run(demo())
+    except KeyboardInterrupt:
+        log.info("Aborted by user")
+
+
 if __name__ == "__main__":
-    asyncio.run(demo())
+    _run()

--- a/src/orca_chat/chains.py
+++ b/src/orca_chat/chains.py
@@ -1,3 +1,4 @@
+from httpx import Timeout
 from langchain.chains import create_history_aware_retriever, create_retrieval_chain
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
@@ -21,7 +22,14 @@ __all__ = [
 
 def build_summarizer(cfg: LLMConfig) -> Runnable:
     """Return a runnable that condenses full chat history into < 250 words."""
-    llm = ChatOllama(base_url=cfg.base_url, **cfg.to_request_dict())
+    llm = ChatOllama(
+        base_url=cfg.base_url,
+        client_kwargs={"timeout": Timeout(cfg.timeout_s)},
+        **cfg.to_request_dict(),
+    ).with_retry(
+        stop_after_attempt=5,
+        exponential_jitter_params={"initial": 1.0, "max": float(cfg.timeout_s)},
+    )
     prompt = ChatPromptTemplate.from_messages(
         [
             SystemMessage("Summarize the conversation so far in < 250 words."),
@@ -51,7 +59,14 @@ def build_chat_core(
     retriever: BaseRetriever | None,
 ) -> Runnable:
     """Assemble prompt → LLM → parser, optionally wrapped with retrieval."""
-    llm = ChatOllama(base_url=cfg.base_url, **cfg.to_request_dict())
+    llm = ChatOllama(
+        base_url=cfg.base_url,
+        client_kwargs={"timeout": Timeout(cfg.timeout_s)},
+        **cfg.to_request_dict(),
+    ).with_retry(
+        stop_after_attempt=5,
+        exponential_jitter_params={"initial": 1.0, "max": float(cfg.timeout_s)},
+    )
     core: Runnable = chat_prompt(cfg, summary) | llm | StrOutputParser()
 
     if retriever:

--- a/src/orca_chat/controller.py
+++ b/src/orca_chat/controller.py
@@ -77,7 +77,12 @@ class ChatController:
         cfg: RunnableConfig = {"configurable": {"session_id": session_id}}
 
         self._stage_tracker.set(session_id, ChatStage.STREAM_FROM_CHAT)
-        result = await chain.ainvoke({"input": message}, config=cfg)
+        try:
+            result = await chain.ainvoke({"input": message}, config=cfg)
+        except Exception:
+            self._stage_tracker.set(session_id, ChatStage.WAITING_FOR_USER)
+            log.exception("Failed to invoke model")
+            raise
         log_result = result.replace("\n", " ")
         log.info(
             "Received reply: [%s, %s] %s (%d chars)",
@@ -116,9 +121,14 @@ class ChatController:
 
         self._stage_tracker.set(session_id, ChatStage.STREAM_FROM_CHAT)
         result = ""
-        async for token in chain.astream({"input": message}, config=cfg):
-            result += token
-            yield str(token)
+        try:
+            async for token in chain.astream({"input": message}, config=cfg):
+                result += token
+                yield str(token)
+        except Exception:
+            self._stage_tracker.set(session_id, ChatStage.WAITING_FOR_USER)
+            log.exception("Failed to stream from model")
+            raise
         yield "\n"
         log_result = result.replace("\n", " ")
         log.info(


### PR DESCRIPTION
## Summary
- retry model calls with backoff
- time out HTTP calls
- handle keyboard interrupts in demo
- log network failures

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865910a818083278f25f6aec39170de