### PR TITLE
Refactor state tracking with dataclasses

### DIFF
--- a/src/orca_chat/controller.py
+++ b/src/orca_chat/controller.py
@@ -17,8 +17,7 @@ from langchain_core.runnables.history import RunnableWithMessageHistory
 
 from orca_chat.chains import build_editor_llm, build_llm
 from orca_chat.config import LLMConfig, LLMRegistry
-from orca_chat.history import SessionState
-from orca_chat.stages import ChatStage, StageTracker
+from orca_chat.state import ChatStage, SessionState, StageTracker
 
 log = logging.getLogger(__name__)
 

--- a/src/orca_chat/history.py
+++ b/src/orca_chat/history.py
@@ -1,9 +1,9 @@
+"""Deprecated module kept for backward compatibility."""
+
+from __future__ import annotations
+
 from langchain_core.chat_history import InMemoryChatMessageHistory
 
+from .state import SessionState
 
-class SessionState:
-    """Lightweight container for per-session state."""
-
-    def __init__(self) -> None:
-        self.history = InMemoryChatMessageHistory()
-        self.precis = ""
+__all__ = ["InMemoryChatMessageHistory", "SessionState"]

--- a/src/orca_chat/stages.py
+++ b/src/orca_chat/stages.py
@@ -1,30 +1,7 @@
-"""Lightweight state tracking for :class:`ChatController`"""
+"""Deprecated module kept for backward compatibility."""
 
-import logging
-from enum import Enum, auto
+from __future__ import annotations
 
-log = logging.getLogger(__name__)
+from .state import ChatStage, StageTracker
 
-
-class ChatStage(Enum):
-    """Discrete states in the chat flow."""
-
-    AWAITING_INPUT = auto()
-    STARTED_STREAM = auto()
-    STARTED_PRECIS = auto()
-
-
-class StageTracker:
-    """Keep track of the current :class:`ChatStage` for each session."""
-
-    def __init__(self) -> None:
-        self._stages: dict[str, ChatStage] = {}
-
-    def set(self, session_id: str, stage: ChatStage) -> None:
-        """Record ``stage`` for ``session_id`` and log the transition."""
-        self._stages[session_id] = stage
-        log.debug("Set stage [%s]: %s", session_id, stage.name)
-
-    def get(self, session_id: str) -> ChatStage:
-        """Return the most recent stage for ``session_id``."""
-        return self._stages.get(session_id, ChatStage.AWAITING_INPUT)
+__all__ = ["ChatStage", "StageTracker"]

--- a/src/orca_chat/state.py
+++ b/src/orca_chat/state.py
@@ -1,0 +1,43 @@
+"""Shared state structures for the chat controller."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+from langchain_core.chat_history import InMemoryChatMessageHistory
+
+log = logging.getLogger(__name__)
+
+
+class ChatStage(Enum):
+    """Discrete states in the chat flow."""
+
+    AWAITING_INPUT = auto()
+    STARTED_STREAM = auto()
+    STARTED_PRECIS = auto()
+
+
+@dataclass(slots=True)
+class SessionState:
+    """Lightweight container for per-session state."""
+
+    history: InMemoryChatMessageHistory = field(default_factory=InMemoryChatMessageHistory)
+    precis: str = ""
+
+
+@dataclass(slots=True)
+class StageTracker:
+    """Keep track of the current :class:`ChatStage` for each session."""
+
+    _stages: dict[str, ChatStage] = field(default_factory=dict)
+
+    def set(self, session_id: str, stage: ChatStage) -> None:
+        """Record ``stage`` for ``session_id`` and log the transition."""
+        self._stages[session_id] = stage
+        log.debug("Set stage [%s]: %s", session_id, stage.name)
+
+    def get(self, session_id: str) -> ChatStage:
+        """Return the most recent stage for ``session_id``."""
+        return self._stages.get(session_id, ChatStage.AWAITING_INPUT)


### PR DESCRIPTION
## Summary
- add `state.py` with dataclass versions of `SessionState` and `StageTracker`
- keep `history.py` and `stages.py` as thin wrappers
- import from `state.py` in `controller`

## Testing
- `ruff --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cac433cc8327b5db03eefbc19516